### PR TITLE
fixed a bug in get_next_net and added a test case

### DIFF
--- a/tekton/connected.py
+++ b/tekton/connected.py
@@ -78,7 +78,7 @@ class ConnectedSyn(object):
         """Get the next subnet to be assigned to interfaces"""
         family = 32 if isinstance(net, IPv4Network) else 128
         base = int(net.network_address)
-        next_addr = ip_address(base + ((family - net.prefixlen) ** 2) + 1)
+        next_addr = ip_address(base + (2 ** (family - net.prefixlen)))
         next_net = ip_network(u'%s/%d' % (next_addr, net.prefixlen))
         return next_net
 

--- a/tests/test_connected.py
+++ b/tests/test_connected.py
@@ -2,6 +2,7 @@
 import unittest
 
 from ipaddress import ip_interface
+from ipaddress import ip_network
 
 from tekton.connected import ConnectedSyn
 from tekton.connected import DuplicateAddressError
@@ -202,3 +203,15 @@ class ConnectedTest(unittest.TestCase):
         ret = syn.synthesize()
         # Asserts
         self.assertTrue(ret)
+
+    def test_get_next_net(self):
+        # get some dummy graph
+        graph = self.get_two_nodes()
+
+        syn = ConnectedSyn(graph)
+
+        net = ip_network(u'10.0.0.0/24')
+
+        for i in range(1, 24):
+            net = syn.get_next_net(net)
+            self.assertEqual(net, ip_network(u'10.0.{}.0/24'.format(i)))


### PR DESCRIPTION
removed the `+1` as it is unnecessary and leads to a ValueError by `ipaddress`